### PR TITLE
Fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 *.dvi
 *.xdv
 *-converted-to.*
+*.old
+
 # these rules might exclude image files for figures etc.
 # *.ps
 # *.eps

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ acs-*.bib
 *.glo
 *.gls
 *.glsdefs
+aglossary.tex
 
 # gnuplottex
 *-gnuplottex-*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lsst-texmf"]
+	path = lsst-texmf
+	url = https://github.com/lsst/lsst-texmf

--- a/LDM-672.tex
+++ b/LDM-672.tex
@@ -4,8 +4,8 @@
 
 % Package imports go here.
 
-\input{aglossary.tex}
 \makeglossaries
+\input{aglossary.tex}
 
 % Local commands go here.
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ tex=$(filter-out $(wildcard *aglossary.tex) , $(wildcard *.tex))
 DOC= LDM-672
 SRC= $(DOC).tex
 
-
+export TEXMFHOME = lsst-texmf/texmf
 
 OBJ=$(SRC:.tex=.pdf)
 
@@ -12,16 +12,18 @@ OBJ=$(SRC:.tex=.pdf)
 all: $(OBJ)
 
 $(OBJ): $(tex) aglossary.tex
-	latexmk -bibtex -xelatex -f $(SRC)
-	makeglossaries $(DOC)        
-	xelatex $(SRC)
+	xelatex $(DOC)
+	makeglossaries $(DOC)
+	bibtex $(DOC)
+	xelatex $(DOC)
+	makeglossaries $(DOC)
+	bibtex $(DOC)
+	xelatex $(DOC)
+	xelatex $(DOC)
 
-	
-
-#The generateAcronyms.py  script is in lsst-texmf/bin - put that in the path
 aglossary.tex :$(tex) myacronyms.txt
-	generateAcronyms.py -g   $(tex)
-	generateAcronyms.py -g -u   $(tex) aglossary.tex
+	$(TEXMFHOME)/../bin/generateAcronyms.py -g   $(tex)
+	$(TEXMFHOME)/../bin/generateAcronyms.py -g -u   $(tex) aglossary.tex
 
 clean :
 	latexmk -c


### PR DESCRIPTION
This pulls in a branch of lsst-texmf, which contains the real fixes, as a submodule; `master` of lsst-texmf is still broken.